### PR TITLE
Allow to use string keys in yaml config

### DIFF
--- a/lib/gemfury/command/authorization.rb
+++ b/lib/gemfury/command/authorization.rb
@@ -52,7 +52,8 @@ private
     email, @user_api_key = netrc_conf[netrc_host]
     # Legacy loading from ~/.gem/gemfury
     conf = read_config_file
-    @user_api_key = conf[:gemfury_api_key] if conf[:gemfury_api_key]
+    api_key = conf[:gemfury_api_key] || conf["gemfury_api_key"]
+    @user_api_key = api_key if api_key
   end
 
   def write_credentials!(email)

--- a/spec/gemfury/app_spec.rb
+++ b/spec/gemfury/app_spec.rb
@@ -30,6 +30,22 @@ describe Gemfury::Command::App do
       ensure_gem_uploads(out, 'fury')
     end
 
+    context 'when config keys are strings' do
+      class MyAppStringConfig < Gemfury::Command::App
+        no_commands do
+          def read_config_file
+            { "gemfury_api_key" => 'DEADBEEF' }
+          end
+        end
+      end
+      it 'should upload a valid gem ' do
+        stub_uploads
+        args = ['push', fixture('fury-0.0.2.gem')]
+        out = capture(:stdout) { MyAppStringConfig.start(args) }
+        ensure_gem_uploads(out, 'fury')
+      end
+    end
+
     it 'should upload multiple packages' do
       stub_uploads
       args = ['push', fixture('fury-0.0.2.gem'), fixture('bar-0.0.2.gem')]


### PR DESCRIPTION
It's quite confusing that with current implementation it is required to use symbol keys in ~/.gem/gemfury config:

``` yaml

---
:gemfury_api_key:  <API_KEY>
```

This PR allows to use ordinary YAML keys

``` yaml

---
gemfury_api_key:  <API_KEY>
```
