### PR TITLE
Add new cli option for user_api_key

### DIFF
--- a/lib/gemfury/command/app.rb
+++ b/lib/gemfury/command/app.rb
@@ -4,6 +4,7 @@ class Gemfury::Command::App < Thor
 
   # Impersonation
   class_option :as, :desc => 'Access an account other than your own'
+  class_option :user_api_key, :desc => 'API token to use for commands'
 
   map "-v" => :version
   desc "version", "Show Gemfury version", :hide => true
@@ -167,6 +168,7 @@ private
   end
 
   def with_checks_and_rescues(&block)
+    @user_api_key = options[:user_api_key] if options[:user_api_key]
     with_authorization(&block)
   rescue Gemfury::InvalidGemVersion => e
     shell.say "You have a deprecated Gemfury client", :red

--- a/lib/gemfury/command/app.rb
+++ b/lib/gemfury/command/app.rb
@@ -4,7 +4,7 @@ class Gemfury::Command::App < Thor
 
   # Impersonation
   class_option :as, :desc => 'Access an account other than your own'
-  class_option :user_api_key, :desc => 'API token to use for commands'
+  class_option :api_token, :desc => 'API token to use for commands'
 
   map "-v" => :version
   desc "version", "Show Gemfury version", :hide => true
@@ -168,7 +168,7 @@ private
   end
 
   def with_checks_and_rescues(&block)
-    @user_api_key = options[:user_api_key] if options[:user_api_key]
+    @user_api_key = options[:api_token] if options[:api_token]
     with_authorization(&block)
   rescue Gemfury::InvalidGemVersion => e
     shell.say "You have a deprecated Gemfury client", :red

--- a/lib/gemfury/command/authorization.rb
+++ b/lib/gemfury/command/authorization.rb
@@ -14,8 +14,8 @@ module Gemfury::Command::Authorization
 
 private
   def with_authorization(&block)
-    # Load up the credentials
-    load_credentials!
+    # Load up the credentials if user_api_key is not already set
+    load_credentials! if @user_api_key.nil?
 
     # Attempt the operation and prompt user in case of
     # lack of authorization or a 401 response from the server

--- a/spec/gemfury/app_spec.rb
+++ b/spec/gemfury/app_spec.rb
@@ -36,6 +36,15 @@ describe Gemfury::Command::App do
       out = capture(:stdout) { MyApp.start(args) }
       ensure_gem_uploads(out, 'bar', 'fury')
     end
+
+    context 'when passing user_api_key via the commandline' do
+      it 'should upload a valid gem' do
+        stub_uploads
+        args = ['push', fixture('fury-0.0.2.gem'), "--user_api_key='DEADBEEF'"]
+        out = capture(:stdout) { Gemfury::Command::App.start(args) }
+        ensure_gem_uploads(out, 'fury')
+      end
+    end
   end
 
   describe '#migrate' do
@@ -69,6 +78,17 @@ describe Gemfury::Command::App do
       args = ['migrate', fixture_path]
       out = capture(:stdout) { MyApp.start(args, :shell => sh) }
       ensure_gem_uploads(out, 'bar', 'fury')
+    end
+
+    context 'when passing user_api_key via the commandline' do
+      it 'should upload gems after confirmation' do
+        stub_uploads
+        sh = Thor::Base.shell.new
+        sh.should_receive(:yes?).and_return(true)
+        args = ['migrate', fixture_path, "--user_api_key='DEADBEEF'"]
+        out = capture(:stdout) { Gemfury::Command::App.start(args, :shell => sh) }
+        ensure_gem_uploads(out, 'bar', 'fury')
+      end
     end
   end
 

--- a/spec/gemfury/app_spec.rb
+++ b/spec/gemfury/app_spec.rb
@@ -37,10 +37,10 @@ describe Gemfury::Command::App do
       ensure_gem_uploads(out, 'bar', 'fury')
     end
 
-    context 'when passing user_api_key via the commandline' do
+    context 'when passing api_token via the commandline' do
       it 'should upload a valid gem' do
         stub_uploads
-        args = ['push', fixture('fury-0.0.2.gem'), "--user_api_key='DEADBEEF'"]
+        args = ['push', fixture('fury-0.0.2.gem'), "--api_token='DEADBEEF'"]
         out = capture(:stdout) { Gemfury::Command::App.start(args) }
         ensure_gem_uploads(out, 'fury')
       end
@@ -80,12 +80,12 @@ describe Gemfury::Command::App do
       ensure_gem_uploads(out, 'bar', 'fury')
     end
 
-    context 'when passing user_api_key via the commandline' do
+    context 'when passing api_token via the commandline' do
       it 'should upload gems after confirmation' do
         stub_uploads
         sh = Thor::Base.shell.new
         sh.should_receive(:yes?).and_return(true)
-        args = ['migrate', fixture_path, "--user_api_key='DEADBEEF'"]
+        args = ['migrate', fixture_path, "--api_token='DEADBEEF'"]
         out = capture(:stdout) { Gemfury::Command::App.start(args, :shell => sh) }
         ensure_gem_uploads(out, 'bar', 'fury')
       end


### PR DESCRIPTION
Adding a new command line option —user_api_key to allow passing an api key to the fury cli to prevent being prompted for login credentials.

When using the Fury CLI from either a continuous integration system or with a user account that was created from a GitHub user account, the standard prompt for user credentials does not work correctly.  We would like to be able to push gems to gemfury in both of these situations using the CLI instead of using the website or curl.