### PR TITLE
Extending the Rake tasks with 'as' support

### DIFF
--- a/lib/gemfury/tasks/release.rake
+++ b/lib/gemfury/tasks/release.rake
@@ -4,7 +4,7 @@ require 'gemfury/command'
 
 namespace 'fury' do
   desc "Build gem and push it to Gemfury"
-  task :release, :gemspec do |t, args|
+  task :release, [:gemspec, :as] do |t, args|
     gemspec = args[:gemspec] ||
               FileList["#{Dir.pwd}/*.gemspec"][0]
 
@@ -22,7 +22,11 @@ namespace 'fury' do
       end
 
       gemfile = File.basename(spec.cache_file)
-      Gemfury::Command::App.start(['push', gemfile])
+
+      params = ['push', gemfile]
+      params << "--as=#{args[:as]}" if args[:as]
+
+      Gemfury::Command::App.start(params)
     end
   end
 end


### PR DESCRIPTION
This allows extending the gemfury rake task with '--as' support.

This allows to for example creating a rake task that simply invokes this one, and releases 'as' a company account.

eg:

```ruby
task :release do
  Rake::Task['fury:release'].invoke(nil, 'some_company')
end
```

(passing nil to gemspec allows to not bother filling that in and let it find it like it normally does)