### PR TITLE
Add support to migrate for nupkg files

### DIFF
--- a/lib/gemfury/command/app.rb
+++ b/lib/gemfury/command/app.rb
@@ -1,6 +1,6 @@
 class Gemfury::Command::App < Thor
   include Gemfury::Command::Authorization
-  PackageExtensions = %w(gem egg tar.gz tgz)
+  PackageExtensions = %w(gem egg tar.gz tgz nupkg)
 
   # Impersonation
   class_option :as, :desc => 'Access an account other than your own'


### PR DESCRIPTION
Should be able to use migrate to upload a directory of *.nupkg files