### PR TITLE
Additional package info in `fury list` to match Dashboard info.

### DIFF
--- a/lib/gemfury/command/app.rb
+++ b/lib/gemfury/command/app.rb
@@ -27,11 +27,15 @@ class Gemfury::Command::App < Thor
     with_checks_and_rescues do
       gems = client.list
       shell.say "\n*** GEMFURY PACKAGES ***\n\n"
+
+      va = [ %w{ name kind version privacy } ]
       gems.each do |g|
-        desc, version = g['name'], g.path('latest_version.version')
-        desc << " (#{version ? version : 'beta'})"
-        shell.say desc
+        va << [ g['name'], g['language'],
+                g.path('latest_version.version') || 'beta',
+                g['private'] ? 'private' : 'public ' ]
       end
+
+      shell.print_table(va)
     end
   end
 


### PR DESCRIPTION
Output looks like this:

```
gemfury (deb, 0.8.1.alpha.4.gaa789b1, private)
gemfury (ruby, beta, public)
gemfury (rpm, 0.8.0.rc1-1, public)
```

Kind of messy, when there's many packages. Perhaps, i make it more of a table?

For now, i'll ask for a review in the approach to the change.