### PR TITLE
Updated `fury versions` to include package size and date updated.

### DIFF
--- a/lib/gemfury.rb
+++ b/lib/gemfury.rb
@@ -2,6 +2,7 @@ gem "multi_json",         "~> 1.10"
 gem "faraday",            ">= 0.9.0", "< 0.16.0.pre"
 gem "netrc",              ">= 0.10.0", "< 0.12.0.pre"
 
+require 'time'
 require 'cgi'
 require 'uri'
 require 'netrc'

--- a/lib/gemfury/command/app.rb
+++ b/lib/gemfury/command/app.rb
@@ -44,9 +44,15 @@ class Gemfury::Command::App < Thor
     with_checks_and_rescues do
       versions = client.versions(gem_name)
       shell.say "\n*** #{gem_name.capitalize} Versions ***\n\n"
+
+      va = []
+      va = [ %w{ version uploaded uploaded_by } ]
       versions.each do |v|
-        shell.say v['version']
+        uploaded = Time.parse(v['created_at']).strftime('%F %R %z')
+        va << [ v['version'], uploaded, v['created_by']['name'] ]
       end
+
+      shell.print_table(va)
     end
   end
 

--- a/spec/fixtures/versions.json
+++ b/spec/fixtures/versions.json
@@ -5,7 +5,11 @@
   "platform":"ruby",
   "prerelease":false,
   "created_at":"2011-05-27T00:38:57+00:00",
-  "updated_at":"2011-05-27T00:38:57+00:00"
+  "updated_at":"2011-05-27T00:38:57+00:00",
+  "created_by": {
+    "id":"acct_123ABC",
+    "username": "user1"
+  }
 },{
   "id":6,
   "slug":"example-0.0.2",
@@ -13,5 +17,9 @@
   "platform":"ruby",
   "prerelease":false,
   "created_at":"2011-05-27T00:38:57+00:00",
-  "updated_at":"2011-05-27T00:38:57+00:00"
+  "updated_at":"2011-05-27T00:38:57+00:00",
+  "created_by": {
+    "id":"acct_123ABC",
+    "username": "user1"
+  }
 }]

--- a/spec/gemfury/client_spec.rb
+++ b/spec/gemfury/client_spec.rb
@@ -217,6 +217,7 @@ describe Gemfury::Client do
 
         expect(versions.size).to eq(2)
         expect(versions.first['slug']).to eq('example-0.0.1')
+        expect(versions.first['created_by']['username']).to eq('user1')
       end
     end
   end


### PR DESCRIPTION
Output looks like this:

```
*** Cableguy Versions ***

0.5.2.alpha.1.g83c3230 (24576 bytes, 2018-10-08 10:00 +0000)
0.5.1.pre14 (24576 bytes, 2018-04-17 12:51 +0000)
```
