### PR TITLE
Removed deprecated warnings for has_rdoc, and added tmp/*, pkg/* to .…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ gemfury-*.gem
 Gemfile.lock
 Gemfile.18.lock
 Gemfile.19.lock
+tmp/*
+pkg/*

--- a/gemfury.gemspec
+++ b/gemfury.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |s|
   s.email             = "hello@gemfury.com"
   s.authors           = [ "Michael Rykov" ]
   s.license           = 'MIT'
-  s.has_rdoc          = false
 
   s.executables       = %w(gemfury fury)
   s.files             = %w(README.md) +


### PR DESCRIPTION
Seems to be a very old deprecation / warning:
https://blog.rubygems.org/2009/05/04/1.3.3-released.html