### PR TITLE
Release 0.11.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+*0.11.0*
+
+* No changes
+
 *0.11.0.rc1*
 
 * Progress bar for pushing packages (#52)

--- a/lib/gemfury/version.rb
+++ b/lib/gemfury/version.rb
@@ -1,3 +1,3 @@
 module Gemfury
-  VERSION = '0.11.0.rc1'
+  VERSION = '0.11.0'
 end


### PR DESCRIPTION
Think we missed to add this release commit, since will use this for tagging.

Please merge, then rebase to be right after the tagged commit of v0.11.0.rc1.