### PR TITLE
Support for Faraday v1.0

### DIFF
--- a/gemfury.gemspec
+++ b/gemfury.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency    "multi_json", "~> 1.10"
   s.add_dependency    "thor", ">= 0.14.0", "< 1.0.0.pre"
   s.add_dependency    "netrc", ">= 0.10.0", "< 0.12.0.pre"
-  s.add_dependency    "faraday", ">= 0.9.0", "< 0.18.0.pre"
+  s.add_dependency    "faraday", ">= 0.9.0", "< 1.1"
   s.add_dependency    "highline", ">= 1.6.0", "< 2.1.0.pre"
   s.add_dependency    "progressbar", ">= 1.10.1"
 

--- a/lib/gemfury.rb
+++ b/lib/gemfury.rb
@@ -1,5 +1,5 @@
 gem "multi_json",         "~> 1.10"
-gem "faraday",            ">= 0.9.0", "< 0.18.0.pre"
+gem "faraday",            ">= 0.9.0", "< 1.1"
 gem "netrc",              ">= 0.10.0", "< 0.12.0.pre"
 
 require 'time'


### PR DESCRIPTION
Fixes #65 

This commit relaxes dependency for Faraday after v1.0 was released January 2020. 

As I read the upgrading notes, there is only breaking changes in Faraday error classes (https://github.com/lostisland/faraday/blob/master/UPGRADING.md#faraday-10)

As of current master commit, I see only these references to Faraday::

```
$ git grep -n Faraday::
lib/faraday/adapter/fury_http.rb:4:class Faraday::Adapter
lib/faraday/request/multipart_with_file.rb:6:  class Request::MultipartWithFile < Faraday::Middleware
lib/faraday/request/multipart_with_file.rb:11:            env[:body][key] = Faraday::UploadIO.new(value, mime_type(value), value.path)
lib/gemfury/client.rb:168:        builder.use Faraday::Request::MultipartWithFile
lib/gemfury/client.rb:169:        builder.use Faraday::Request::Multipart
lib/gemfury/client.rb:170:        builder.use Faraday::Request::UrlEncoded
lib/gemfury/client.rb:203:      Faraday::Connection.new(uri) do |f|
lib/gemfury/client/middleware.rb:3:    class Handle503 < Faraday::Middleware
lib/gemfury/client/middleware.rb:12:    class ParseJson < Faraday::Response::Middleware
spec/support/webmock.rb:46:    Faraday::Response.new.finish(:status => 200, :body => '')


$ git show-ref origin/master
e2170bd84ba576431f2b46612717c22c23536b87 refs/remotes/origin/master
```

Besides from that, I am creating this commit blindly, so please review carefully :)