### PR TITLE
Adding "git:config" commands

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 *Unreleased*
 
+* Added commands: git:config, git:config:set, git:config:unset
 * Added Ruby version to User Agent
 
 *0.11.0*

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+*Unreleased*
+
+* Added Ruby version to User Agent
+
 *0.11.0*
 
 * No changes

--- a/lib/gemfury/client.rb
+++ b/lib/gemfury/client.rb
@@ -165,6 +165,30 @@ module Gemfury
       checked_response_body(api.post(url, options))
     end
 
+    # List Git repo's build configuration
+    # @param repo [String] the repo name
+    # @param options [Hash] Faraday client options
+    # @return [Hash]
+    def git_config(repo, options = {})
+      ensure_ready!(:authorization)
+      path = "#{git_repo_path(repo)}/config-vars"
+      response = connection.get(path, options)
+      checked_response_body(response)
+    end
+
+    # Update Git repo's build configuration
+    # @param repo [String] the repo name
+    # @param updates [Hash] Updates to configuration
+    # @param options [Hash] Faraday client options
+    # @return [Hash]
+    def git_config_update(repo, updates, options = {})
+      ensure_ready!(:authorization)
+      path = "#{git_repo_path(repo)}/config-vars"
+      opts = options.merge(:config_vars => updates)
+      response = connection.patch(path, opts)
+      checked_response_body(response)
+    end
+
   private
     def escape(str)
       CGI.escape(str)

--- a/lib/gemfury/command/app.rb
+++ b/lib/gemfury/command/app.rb
@@ -224,6 +224,40 @@ class Gemfury::Command::App < Thor
     end
   end
 
+  ### GIT REPOSITORY BUILD CONFIG ###
+  map 'git:config'       => 'git_config'
+  map 'git:config:set'   => 'git_config_set'
+  map 'git:config:unset' => 'git_config_unset'
+
+  desc "git:config", "List Git repository's build environment"
+  def git_config(repo)
+    with_checks_and_rescues do
+      vars = client.git_config(repo)['config_vars']
+      shell.say "*** #{repo} build config ***\n"
+      shell.print_table(vars.map { |kv|
+        ["#{kv[0]}:", kv[1]]
+      })
+    end
+  end
+
+  desc "git:config:set", "Update Git repository's build environment"
+  def git_config_set(repo, *vars)
+    with_checks_and_rescues do
+      updates = Hash[vars.map { |v| v.split("=", 2) }]
+      client.git_config_update(repo, updates)
+      shell.say "Updated #{repo} build config"
+    end
+  end
+
+  desc "git:config:unset", "Remove variables from Git repository's build environment"
+  def git_config_unset(repo, *vars)
+    with_checks_and_rescues do
+      updates = Hash[vars.map { |v| [v, nil] }]
+      client.git_config_update(repo, updates)
+      shell.say "Updated #{repo} build config"
+    end
+  end
+
 private
   def client
     opts = {}

--- a/lib/gemfury/configuration.rb
+++ b/lib/gemfury/configuration.rb
@@ -7,7 +7,7 @@ module Gemfury
       :endpoint => 'https://api.fury.io/',
       :gitpoint => 'https://git.fury.io/',
       :pushpoint => 'https://push.fury.io/',
-      :user_agent => "Gemfury RubyGem #{Gemfury::VERSION}",
+      :user_agent => "Gemfury RubyGem #{Gemfury::VERSION} (Ruby #{RUBY_VERSION})",
       :api_version => 1,
       :account => nil
     }.freeze

--- a/spec/fixtures/git_config.json
+++ b/spec/fixtures/git_config.json
@@ -1,0 +1,6 @@
+{
+  "config_vars": {
+    "HELLO": "WORLD",
+    "SUPER": "SECRET"
+  }
+}

--- a/spec/gemfury/client_spec.rb
+++ b/spec/gemfury/client_spec.rb
@@ -403,6 +403,48 @@ describe Gemfury::Client do
     end
   end
 
+  describe '#git_config' do
+    let(:stub_api_method)  { stub_get('git/repos/me/example/config-vars') }
+    let(:send_api_request) { @client.git_config('example') }
+
+    it_should_behave_like 'API without authentication'
+
+    describe 'while authenticated' do
+      before do
+        stub_api_method.to_return(:body => fixture('git_config.json'))
+        @client.user_api_key = 'MyAuthKey'
+      end
+
+      it 'should list git repo config variables' do
+        vars = send_api_request['config_vars']
+        expect(a_get('git/repos/me/example/config-vars')).to have_been_made
+        expect(vars).to eq({ "HELLO" => "WORLD", "SUPER" => "SECRET" })
+      end
+    end
+  end
+
+  describe '#git_config_update' do
+    let(:update_payload)   { { "NEW" => "VAR"} }
+    let(:stub_api_method)  { stub_patch('git/repos/me/example/config-vars') }
+    let(:send_api_request) { @client.git_config_update('example', update_payload) }
+
+    it_should_behave_like 'API without authentication'
+
+    describe 'while authenticated' do
+      before do
+        stub_api_method.to_return(:body => fixture('git_config.json'))
+        @client.user_api_key = 'MyAuthKey'
+      end
+
+      it 'should list git repo config variables' do
+        vars = send_api_request['config_vars']
+        body = Faraday::NestedParamsEncoder.encode('config_vars' => update_payload)
+        expect(a_patch('git/repos/me/example/config-vars', :body => body)).to have_been_made
+        expect(vars).to eq({ "HELLO" => "WORLD", "SUPER" => "SECRET" })
+      end
+    end
+  end
+
   def access_token_fixture
     ::MultiJson.encode(:token => 'TestToken')
   end


### PR DESCRIPTION
Adding Git build configuration management via commands `git:config`, `git:config:set`, and `git:config:unset`.