### PR TITLE
Fix Thor deprecation warning to be explicit in returning 0

### DIFF
--- a/lib/gemfury/command/app.rb
+++ b/lib/gemfury/command/app.rb
@@ -10,6 +10,9 @@ class Gemfury::Command::App < Thor
   class_option :as, :desc => 'Access an account other than your own'
   class_option :api_token, :desc => 'API token to use for commands'
 
+  # Make sure we retain the default exit behaviour of 0 even on argument errors
+  def self.exit_on_failure?; false; end
+
   map "-v" => :version
   desc "version", "Show Gemfury version", :hide => true
   def version


### PR DESCRIPTION
There's a deprecation warning in Thor 1.0. See here:
https://github.com/erikhuda/thor/blob/99330185faa6ca95e57b19a402dfe52b1eba8901/lib/thor/base.rb#L529

To retain legacy behaviour, the `exit_on_failure?` class method needs to be defined, to return `False`. `True` if we want it to return an error code (e.g. `1`).

We can support the new behaviour, or retain it. What do you think?