### PR TITLE
When using fury CLI app default to disable warnings.

### DIFF
--- a/bin/fury
+++ b/bin/fury
@@ -7,4 +7,8 @@ require 'rubygems'
 require 'gemfury'
 require 'gemfury/command'
 
+if defined?(Warning) && Warning.respond_to?('[]')
+  Warning[:deprecated] = !!ENV['DEBUG']
+end
+
 Gemfury::Command::App.start


### PR DESCRIPTION
This make sense to do when using the fury CLI app, since the warnings offers no value at this stage. It's only valuable when in development.

Ruby 2.7.x has many deprecation warnings, and found Matz verbal position on the case [here](https://bugs.ruby-lang.org/issues/16345#note-46).