### PR TITLE
Enable all File-like objects to be used for uploading

### DIFF
--- a/lib/faraday/request/multipart_with_file.rb
+++ b/lib/faraday/request/multipart_with_file.rb
@@ -7,25 +7,24 @@ module Faraday
     def call(env)
 
       if env[:body].is_a?(Hash)
-        
-        # Check for IO (and IO-like objects, like Zip::InputStream) in the request, 
-        # which represent data to be uploaded.  Replace these with Faraday 
+
+        # Check for IO (and IO-like objects, like Zip::InputStream) in the request,
+        # which represent data to be uploaded.  Replace these with Faraday
         env[:body].each do |key, value|
-          
+
           # Faraday seems to expect a few IO methods to be available, but that's all:
           # https://github.com/lostisland/faraday/blob/master/lib/faraday/file_part.rb
           # :length seems to be an optional one
           #
           # UploadIO also seems to do a duck typing check for :read, with :path optional
           # https://www.rubydoc.info/gems/multipart-post/2.0.0/UploadIO:initialize
-          # 
+          #
           # We attempt to make our duck typing compatible with their duck typing
           if value.respond_to?(:read) && value.respond_to?(:rewind) && value.respond_to?(:close)
             # Mimic UploadIO's handling of inputs like StringIO, which don't have a :path method
             local_path = value.respond_to?(:path) ? value.path : 'local.path'
-            local_mime = value.respond_to?(:path) ? mime_type(value) : 'application/octet-stream'
-            
-            env[:body][key] = Faraday::UploadIO.new(value, local_mime, local_path)
+
+            env[:body][key] = Faraday::UploadIO.new(value, mime_type(value), local_path)
           end
         end
       end
@@ -36,6 +35,9 @@ module Faraday
     private
 
     def mime_type(file)
+      default = 'application/octet-stream'
+      return default unless file.respond_to?(:path)
+
       case file.path
       when /\.jpe?g/i
         'image/jpeg'
@@ -44,7 +46,7 @@ module Faraday
       when /\.png$/i
         'image/png'
       else
-        'application/octet-stream'
+        default
       end
     end
   end

--- a/lib/faraday/request/multipart_with_file.rb
+++ b/lib/faraday/request/multipart_with_file.rb
@@ -22,9 +22,7 @@ module Faraday
           # We attempt to make our duck typing compatible with their duck typing
           if value.respond_to?(:read) && value.respond_to?(:rewind) && value.respond_to?(:close)
             # Mimic UploadIO's handling of inputs like StringIO, which don't have a :path method
-            local_path = value.respond_to?(:path) ? value.path : 'local.path'
-
-            env[:body][key] = Faraday::UploadIO.new(value, mime_type(value), local_path)
+            env[:body][key] = Faraday::UploadIO.new(value, mime_type(value))
           end
         end
       end

--- a/lib/faraday/request/multipart_with_file.rb
+++ b/lib/faraday/request/multipart_with_file.rb
@@ -6,20 +6,26 @@ module Faraday
   class Request::MultipartWithFile < Faraday::Middleware
     def call(env)
 
-      # Faraday seems to expect a few IO methods to be available, but that's all:
-      # https://github.com/lostisland/faraday/blob/master/lib/faraday/file_part.rb
-      # :length seems to be an optional one
-      #
-      # UploadIO also seems to do a duck typing check for :read, with :path optional
-      # https://www.rubydoc.info/gems/multipart-post/2.0.0/UploadIO:initialize
-      required_io_methods = ["rewind", "read", "close"].map(&:to_sym)
-
       if env[:body].is_a?(Hash)
+        
+        # Check for IO (and IO-like objects, like Zip::InputStream) in the request, 
+        # which represent data to be uploaded.  Replace these with Faraday 
         env[:body].each do |key, value|
-          # Allow both IO derivates, and IO-like objects via duck typing
-          # (e.g. Zip::InputStream) 
-          if value.is_a?(IO) || required_io_methods.all? { |m| value.respond_to? (m) }
-            env[:body][key] = Faraday::UploadIO.new(value, mime_type(value), value.path)
+          
+          # Faraday seems to expect a few IO methods to be available, but that's all:
+          # https://github.com/lostisland/faraday/blob/master/lib/faraday/file_part.rb
+          # :length seems to be an optional one
+          #
+          # UploadIO also seems to do a duck typing check for :read, with :path optional
+          # https://www.rubydoc.info/gems/multipart-post/2.0.0/UploadIO:initialize
+          # 
+          # We attempt to make our duck typing compatible with their duck typing
+          if value.respond_to?(:read) && value.respond_to?(:rewind) && value.respond_to?(:close)
+            # Mimic UploadIO's handling of inputs like StringIO, which don't have a :path method
+            local_path = value.respond_to?(:path) ? value.path : 'local.path'
+            local_mime = value.respond_to?(:path) ? mime_type(value) : 'application/octet-stream'
+            
+            env[:body][key] = Faraday::UploadIO.new(value, local_mime, local_path)
           end
         end
       end


### PR DESCRIPTION
Hard-coding the `File` class as a condition for uploading a file prevents other legitimate `IO`-compatible stream objects (e.g. `StringIO`) from being used as input.  This can cause cryptic errors to be returned to the end user from the Gemfury server about `multipart/form-data` not being used, when in fact the Faraday request middleware has failed to recognize a file being supplied.

```
	16: from /Users/ianfixes/Development/Public Github/gemfury/lib/gemfury/client.rb:38:in `push_gem'
	15: from /Users/ianfixes/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/faraday-1.0.1/lib/faraday/connection.rb:279:in `post'
	14: from /Users/ianfixes/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/faraday-1.0.1/lib/faraday/connection.rb:492:in `run_request'
	13: from /Users/ianfixes/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/faraday-1.0.1/lib/faraday/rack_builder.rb:153:in `build_response'
	12: from /Users/ianfixes/Development/Public Github/gemfury/lib/faraday/request/multipart_with_file.rb:21:in `call'
	11: from /Users/ianfixes/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/faraday-1.0.1/lib/faraday/request/multipart.rb:25:in `call'
	10: from /Users/ianfixes/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/faraday-1.0.1/lib/faraday/request/url_encoded.rb:25:in `call'
	 9: from /Users/ianfixes/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/faraday-1.0.1/lib/faraday/response.rb:11:in `call'
	 8: from /Users/ianfixes/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/faraday-1.0.1/lib/faraday/response.rb:65:in `on_complete'
	 7: from /Users/ianfixes/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/faraday-1.0.1/lib/faraday/response.rb:12:in `block in call'
	 6: from /Users/ianfixes/Development/Public Github/gemfury/lib/gemfury/client/middleware.rb:19:in `on_complete'
	 5: from /Users/ianfixes/Development/Public Github/gemfury/lib/gemfury/client/middleware.rb:14:in `parse'
	 4: from /Users/ianfixes/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/multi_json-1.15.0/lib/multi_json.rb:122:in `load'
	 3: from /Users/ianfixes/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/multi_json-1.15.0/lib/multi_json/adapter.rb:21:in `load'
	 2: from /Users/ianfixes/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/multi_json-1.15.0/lib/multi_json/adapters/json_common.rb:14:in `load'
	 1: from /Users/ianfixes/.rbenv/versions/2.7.1/lib/ruby/2.7.0/json/common.rb:156:in `parse'
/Users/ianfixes/.rbenv/versions/2.7.1/lib/ruby/2.7.0/json/common.rb:156:in `parse': 783: unexpected token at 'ERROR: Please use multipart/form-data upload (RFC-2388) (MultiJson::ParseError)
Correct your erring ways via the Dev Center:
https://fury.help/g/errors/push-multipart
https://fury.help/g/upload-packages

'
```

This patch loosens the criteria to simply testing for some of the methods that Faraday will need to process the input stream: 
https://github.com/lostisland/faraday/blob/master/lib/faraday/file_part.rb

Experimentally, although ["rewind", "read", "close", "length", and "ensure_open_and_readable"] are referred to in Faraday's `CompositeReadIO`, passing [an object with ["rewind", "read", "close"] implemented](https://www.rubydoc.info/github/rubyzip/rubyzip/Zip/InputStream) seems to produce the expected behavior.

Code that is currently expected to work, but doesn't:

```ruby
client = Gemfury::Client.new({ user_api_key: ENV["GEMFURY_PUSH_TOKEN"] })
  
aws_codepipeline_artifact_zip_file_containing_gem = "/path/to/tmp.zip"
Zip::File.open(aws_codepipeline_artifact_zip_file_containing_gem) do |zip_file|
  zip_file.map do |entry|
    next puts "  This doesn't look like *.gem: #{entry.name}" unless entry.name.end_with? ".gem"

    entry.get_input_stream do |gem_io|
      gemfury_resp = client.push_gem(gem_io, { public: nil })
    end
  end
end
```

Code that currently actually works:

```ruby
client = Gemfury::Client.new({ user_api_key: ENV["GEMFURY_PUSH_TOKEN"] })
  
aws_codepipeline_artifact_zip_file_containing_gem = "/path/to/tmp.zip"
Zip::File.open(aws_codepipeline_artifact_zip_file_containing_gem) do |zip_file|
  zip_file.map do |entry|
    next puts "  This doesn't look like *.gem: #{entry.name}" unless entry.name.end_with? ".gem"

    entry.get_input_stream do |gem_io|
      # copy the file to disk so we can then reopen it as something that `is_a? File` ... ugh
      Tempfile.create(["codepipeline_artifact_unzipped", ".gem"]) do |tf|
        bytes = IO.copy_stream(gem_io, tf)
        tf.rewind  # and woe upon you if you forget it

        gemfury_resp = client.push_gem(tf, { public: nil })
      end
    end
  end
end
```

This PR makes the "expected to work" code _actually_ work.