### PR TITLE
locked in rexml,fakefs,rexml to gems working at ruby 2.0

### DIFF
--- a/spec/gemfiles/Gemfile.20
+++ b/spec/gemfiles/Gemfile.20
@@ -11,11 +11,13 @@ group :development do
   gem "webmock", "~> 3.8.3"
   gem "rspec", "~> 3.0"
   gem "multi_json"
-  gem 'fakefs'
+
   gem "json"
-  gem "rexml"
   gem "yard"
 
   # Restrict for Ruby 2.0 compatibility
   gem 'public_suffix', '< 3.0.0.pre'
+  gem 'fakefs', '< 0.14.0'
+  gem 'faraday', '< 1.0.0'
+  gem 'rexml', '< 3.2.5'
 end

--- a/spec/gemfiles/Gemfile.21
+++ b/spec/gemfiles/Gemfile.21
@@ -11,11 +11,13 @@ group :development do
   gem "webmock", "~> 3.8.3"
   gem "rspec", "~> 3.0"
   gem "multi_json"
-  gem 'fakefs'
+
   gem "json"
-  gem "rexml"
   gem "yard"
 
   # Restrict for Ruby 2.1 compatibility
   gem 'public_suffix', '< 4.0.0.pre'
+  gem 'fakefs', '< 0.14.0'
+  gem 'faraday', '< 1.0.0'
+  gem 'rexml', '< 3.2.5'
 end


### PR DESCRIPTION
Yo, found the latest version of the gems required by spec under ruby 2.0, 2.1  environment.