### PR TITLE
Update UA to include system information and ruby platform details.

### DIFF
--- a/lib/gemfury/client.rb
+++ b/lib/gemfury/client.rb
@@ -1,3 +1,5 @@
+require 'rbconfig'
+
 module Gemfury
   class Client
     include Gemfury::Client::Filters
@@ -213,7 +215,7 @@ module Gemfury
         :params => {},
         :headers => {
           :accept => http_accept,
-          :user_agent => self.user_agent,
+          :user_agent => finalize_user_agent(self.user_agent),
           :x_gem_version => Gemfury::VERSION,
         }.merge(options.delete(:headers) || {})
       }.merge(options)
@@ -268,6 +270,36 @@ module Gemfury
         :content_length => file.stat.size.to_s,
         :content_type => ''
       })
+    end
+
+    def finalize_user_agent(ua)
+      if defined?(@final_ua)
+        @final_ua
+      else
+        @final_ua = '%s (%s) ruby/%s (%s)' % [ ua, determine_system_info,
+                                               RUBY_VERSION, RUBY_PLATFORM ]
+      end
+    end
+
+    def determine_system_info
+      host_os = RbConfig::CONFIG['host_os']
+
+      case host_os
+      when /darwin/i
+        os_type = 'Macintosh'
+        rel = '' #TODO
+      when /linux/i
+        os_type = 'Linux'
+        rel = '' #TODO
+      when /windows/i
+        os_type = 'Windows'
+        rel = '' #TODO
+      else
+        os_type = ''
+        rel = '' #TODO
+      end
+
+      '%s; %s; %s' % [ os_type, rel, host_os ]
     end
   end
 end

--- a/lib/gemfury/command/app.rb
+++ b/lib/gemfury/command/app.rb
@@ -3,7 +3,7 @@ require 'delegate'
 
 class Gemfury::Command::App < Thor
   include Gemfury::Command::Authorization
-  UserAgent = "Gemfury CLI #{Gemfury::VERSION}".freeze
+  UserAgent = "GemfuryCLI/#{Gemfury::VERSION}".freeze
   PackageExtensions = %w(gem egg tar.gz tgz nupkg)
 
   # Impersonation

--- a/lib/gemfury/configuration.rb
+++ b/lib/gemfury/configuration.rb
@@ -7,7 +7,7 @@ module Gemfury
       :endpoint => 'https://api.fury.io/',
       :gitpoint => 'https://git.fury.io/',
       :pushpoint => 'https://push.fury.io/',
-      :user_agent => "Gemfury RubyGem #{Gemfury::VERSION} (Ruby #{RUBY_VERSION})",
+      :user_agent => "GemfuryGem/#{Gemfury::VERSION}",
       :api_version => 1,
       :account => nil
     }.freeze


### PR DESCRIPTION
@rykov Initial take. This will produce a UA string like:

```
GemfuryCLI/0.12.0 (Macintosh; ; darwin20.2.0) ruby/2.7.2 (x86_64-darwin20)
```

Reference point:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent

Following this common format:

```
User-Agent: <App>/<App version> (<system-information>) <platform> (<platform-details>) <extensions>
```

This will at minimum, work with the `browser` gem, to detect Windows, Mac, or Linux.

I haven't added the system version yet, since it's a bit tricky. I've looked around at other gems, and they seem to be excessive to add. So wondering if it's worth adding the system version, on top of the already built-in values provided by `RUBY_PLATFORM` and `RbConfig::CONFIG['host_os']`.

Alrighty, please let me know. I haven't added any specs yet, since want to finalize the details in UA first.